### PR TITLE
299 empty label if formswitch doesnt have label

### DIFF
--- a/src/lib/form/FormSwitch.svelte
+++ b/src/lib/form/FormSwitch.svelte
@@ -19,7 +19,6 @@
 	export let checked: $$Props['checked'] = undefined
 	export let inline: $$Props['inline'] = undefined
 
-
 	let props: $$Props = {}
 	let switchProps: SwitchProps = {}
 

--- a/src/lib/form/FormSwitch.svelte
+++ b/src/lib/form/FormSwitch.svelte
@@ -55,8 +55,10 @@
 		{...switchProps}
 		bind:checked
 		bind:value
-		on:change>
+		on:change
+		_slots={{ default: $$slots['default'], description: $$slots['description'] }}>
 		<slot />
+		<slot name="description" slot="description" />
 	</Switch>
 	<slot name="hint" />
 </FormField>

--- a/src/lib/switch/Switch.svelte
+++ b/src/lib/switch/Switch.svelte
@@ -62,18 +62,20 @@
 		on:blur />
 	{#if label || _slots['default']}
 		<Label for={_for} componentName="{componentName}-label">
-			<slot>
-				{#if label}
-					{label}
-				{/if}
-			</slot>
+			{#if _slots['default']}
+				<slot />
+			{:else}
+				{label}
+			{/if}
 		</Label>
 	{/if}
 	{#if description || _slots['description']}
 		<El componentName="{componentName}-description">
-			<slot name="description">
+			{#if _slots['description']}
+				<slot name="description" />
+			{:else}
 				{description}
-			</slot>
+			{/if}
 		</El>
 	{/if}
 </El>

--- a/src/lib/switch/Switch.svelte
+++ b/src/lib/switch/Switch.svelte
@@ -19,6 +19,7 @@
 	export let checked: $$Props['checked'] = false
 	export let role: $$Props['role'] = 'switch'
 	export let type: $$Props['type'] = 'checkbox'
+	export let _slots: Record<string, boolean> = $$slots
 
 	function onChange(event: any) {
 		checked = event.target.checked
@@ -59,7 +60,7 @@
 		on:focus
 		on:input
 		on:blur />
-	{#if label || $$slots['default']}
+	{#if label || _slots['default']}
 		<Label for={_for} componentName="{componentName}-label">
 			<slot>
 				{#if label}
@@ -68,7 +69,7 @@
 			</slot>
 		</Label>
 	{/if}
-	{#if description || $$slots['description']}
+	{#if description || _slots['description']}
 		<El componentName="{componentName}-description">
 			<slot name="description">
 				{description}

--- a/src/lib/switch/Switch.types.ts
+++ b/src/lib/switch/Switch.types.ts
@@ -10,4 +10,5 @@ export interface SwitchProps extends Partial<ElProps> {
 	description?: string
 	type?: string
 	name?: string
+	_slots?: Record<string, boolean>
 }


### PR DESCRIPTION
In this PR I worked on slot forwarding for Switch and FormSwitch.

now FormSwitch supports `description` and `default` slots.