### PR TITLE
fix missing link to /docs/introduction on Explore all features button

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -345,7 +345,7 @@
 								</TabPanel>
 							</TabContent>
 							<El mt="3" pt="2" textAlign="center">
-								<Button>
+								<Button href="/docs/introduction">
 									Explore all features <Icon name="arrow-right" />
 								</Button>
 							</El>


### PR DESCRIPTION
Hi,
it seems the `href` attribute for the second "Explore all features" link on the home page is missing.