### PR TITLE
Fix an off-by-one-date error in DatePicker

### DIFF
--- a/src/lib/date-picker/DatePicker.svelte
+++ b/src/lib/date-picker/DatePicker.svelte
@@ -12,7 +12,6 @@
 
 	export let componentName: $$Props['componentName'] = 'date-picker'
 	export let formatText: $$Props['formatText'] = undefined
-	export let formatValue: $$Props['formatValue'] = undefined
 	export let borderRounded: $$Props['borderRounded'] = undefined
 	export let borderFlush: $$Props['borderFlush'] = undefined
 	export let disabled: $$Props['disabled'] = undefined
@@ -50,23 +49,19 @@
 		}
 	}
 
-	function format(date: Date | DateTime | null | undefined, mode = 'value'): Date | string {
+	function formatValue(date: DateTime | null | undefined): string {
+		return date ? date.format('YYYY-MM-DD') : ''
+	}
+	function format(date: Date | DateTime | null | undefined, mode: 'text'): Date | string {
 		if (!date) return ' --- '
 		if (date.toJSDate) date = date.toJSDate()
 
 		if (date) {
-			if (mode === 'value') {
-				if (formatValue) {
-					return formatValue(date)
-				}
-				return new Date(date).toISOString()
-			} else {
-				if (formatText) {
-					return formatText(date)
-				}
-
-				return new Date(date).toDateString()
+			if (formatText) {
+				return formatText(date)
 			}
+
+			return new Date(date).toDateString()
 		}
 		return ''
 	}
@@ -144,16 +139,13 @@
 				}
 			})
 
-			picker.on('selected', (event: any) => {
+			picker.on('selected', (date1: DateTime | null, date2: DateTime | null | undefined) => {
 				if (range) {
-					const startDate = instance?.getStartDate()
-					const startDateValue = format(startDate)
-					const startDateText = format(startDate, 'text')
+					const startDateValue = formatValue(date1)
+					const startDateText = format(date1, 'text')
 
-					const endDate = instance?.getEndDate()
-
-					const endDateValue = format(endDate)
-					const endDateText = format(endDate, 'text')
+					const endDateValue = formatValue(date2)
+					const endDateText = format(date2, 'text')
 
 					if (value[0] === startDateValue && value[1] === endDateValue) return
 
@@ -162,9 +154,8 @@
 					text = startDateText + ' - ' + endDateText
 					dispatch('changed', value)
 				} else {
-					const date = event?.dateInstance
-					const dateValue = format(date)
-					const dateText = format(date, 'text')
+					const dateValue = formatValue(date1)
+					const dateText = format(date1, 'text')
 
 					if (value === dateValue) return
 

--- a/src/lib/date-picker/DatePicker.types.ts
+++ b/src/lib/date-picker/DatePicker.types.ts
@@ -4,7 +4,6 @@ import type { InputSizes, InputStates } from '../input/Input.types'
 
 export interface DatePickerProps extends Partial<ElProps> {
 	formatText?: (date: Date) => string
-	formatValue?: (date: Date) => string | Date
 	value?: Date | string | number | Array<Date | string | number>
 	text?: string
 	options?: Partial<ILPConfiguration>


### PR DESCRIPTION
[DatePicker](https://www.yesvelte.com/docs/date-picker) currently selects the previous date in the eastern hemisphere (when the timezone offset is positive — `+HH:MM`):

0. Ensure your time zone offset is positive (e.g. Europe Standard time / +01:00)
1. Go to https://www.yesvelte.com/docs/date-picker
2. Click the input box in the "Default" example
3. Select 2023-08-05 from the date picker
4. Note that the input box now contains a date, that's off by one day: `Fri Aug 04 2023`, and the value is additionally offset by one hour: `2023-08-03T23:00:00.000Z`

What happens is: the [`selected` event](https://litepicker.com/docs/events#selected) provides a litepicker-specific [`DateTime` object](https://github.com/wakirin/Litepicker/blob/33bbcbb62b91a40006172aee7e419f558a4a4dcb/src/datetime.ts#L1), which is [converted](https://github.com/yesvelte/yesvelte/blob/a1dcfa33c64b3838fb32038f038c4cf222f38d21/src/lib/date-picker/DatePicker.svelte#L165-L166) to a `Date` and then to a  yesvelte's `value`. The value is immediately [assigned back](https://github.com/yesvelte/yesvelte/blob/a1dcfa33c64b3838fb32038f038c4cf222f38d21/src/lib/date-picker/DatePicker.svelte#L47) to the litepicker, which [expects](https://litepicker.com/docs/methods#setdate) a string in the configured [format](https://litepicker.com/docs/options#format) <sub>(or, alternatively, a JS `Date`, or a `Number` of milliseconds since 1970-01-01).</sub>

More specifically:

* The JS `Date` object actually represents a datetime value. It's initialized to **midnight local time** (e.g. `2023-08-05T00:00:00+01:00` for Aug-05 selected from the picker).
* The default `formatValue` behavior [is](https://github.com/yesvelte/yesvelte/blob/a1dcfa33c64b3838fb32038f038c4cf222f38d21/src/lib/date-picker/DatePicker.svelte#L62) `new Date(date).toISOString()` converting to a string in the UTC timezone (e.g. `"2023-08-04T23:00:00Z"`, note the difference in the date: Aug-05 vs Aug-04).
* Litepicker's `new DateTime("2023-08-04T23:00:00Z")` [ignores the time part](https://github.com/wakirin/Litepicker/blob/33bbcbb62b91a40006172aee7e419f558a4a4dcb/src/datetime.ts#L68), so the selected date changes to one day before (`2023-08-04`).

The format of the DatePicker's `value` is not currently specified, but I think it should just always be a string in the `YYYY-MM-DD` format. Letting the user to provide her own `formatValue` function, expecting its output to be compatible with the litepicker's parser is not very intuitive.