### PR TITLE
Fix installation instructions for tabler

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ YeSvelte components have default styles which is based on tabler. which you can 
 </script>
 
 <svelte:head>
-	<link rel="stylesheet" href="https://unpkg.com/yesvelte@next/css/tabler.min.css" />
+	<link rel="stylesheet" href="https://unpkg.com/yesvelte@next/dist/css/tabler.min.css" />
 </svelte:head>
 
 <Button color="primary">Hello YeSvelte!</Button>


### PR DESCRIPTION
The docs as written currently cause a 404 when loading tabler. I found that the css if actually in the `dist` folder on npm and if I change the docs to include the `dist` directory, the css loads. This fixes the docs.